### PR TITLE
Now you can set LLVM_CONFIG when you run build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ then
     JFLAG="-j8"
 fi
 
-LLVM_CONFIG="/usr/lib/llvm/14/bin/llvm-config"
+LLVM_CONFIG=${LLVM_CONFIG:-"/usr/lib/llvm/14/bin/llvm-config"}
 FLAGS="$JFLAG -I$($LLVM_CONFIG --includedir) -L-L$($LLVM_CONFIG --libdir)"
 
 TAG=v0.1.9


### PR DESCRIPTION
As the title says.
What I needed was something like this to work: `LLVM_CONFIG=/usr/bin/llvm-config-14 ./build.sh`