### PR TITLE
Use /usr/bin/llvm-config-14

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ then
     JFLAG="-j8"
 fi
 
-LLVM_CONFIG=${LLVM_CONFIG:-"/usr/lib/llvm/14/bin/llvm-config"}
+LLVM_CONFIG=${LLVM_CONFIG:-"/usr/bin/llvm-config-14"}
 FLAGS="$JFLAG -I$($LLVM_CONFIG --includedir) -L-L$($LLVM_CONFIG --libdir)"
 
 TAG=v0.2.1

--- a/release-gcc.sh
+++ b/release-gcc.sh
@@ -116,28 +116,22 @@ fi
 rm neat_bootstrap
 EOT
 else
-    if [ -f "/usr/lib/llvm/14/bin/llvm-config" ]
+    if [ -f "/usr/bin/llvm-config-14" ]
     then
-        LLVM_CONFIG="/usr/lib/llvm/14/bin/llvm-config"
-    elif [ -f "/usr/lib/llvm-14/bin/llvm-config" ]
-    then
-        LLVM_CONFIG="/usr/lib/llvm-14/bin/llvm-config"
+        LLVM_CONFIG="/usr/bin/llvm-config-14"
     else
-        echo "Cannot find llvm-config!" 1>&2
+        echo "Cannot find llvm-config-14!" 1>&2
         exit 1
     fi
     CFLAGS="${CFLAGS:+ }-I$($LLVM_CONFIG --includedir) -L$($LLVM_CONFIG --libdir)"
     cat > $TARGET/build.sh <<EOT
 #!/usr/bin/env bash
 set -exo pipefail
-if [ -f "/usr/lib/llvm/14/bin/llvm-config" ]
+if [ -f "/usr/bin/llvm-config-14" ]
 then
-    LLVM_CONFIG="/usr/lib/llvm/14/bin/llvm-config"
-elif [ -f "/usr/lib/llvm-14/bin/llvm-config" ]
-then
-    LLVM_CONFIG="/usr/lib/llvm-14/bin/llvm-config"
+    LLVM_CONFIG="/usr/bin/llvm-config-14"
 else
-    echo "Cannot find llvm-config!" 1>&2
+    echo "Cannot find llvm-config-14!" 1>&2
     exit 1
 fi
 LLVM_CFLAGS="-I\$(\$LLVM_CONFIG --includedir) -L\$(\$LLVM_CONFIG --libdir)"

--- a/unittest.sh
+++ b/unittest.sh
@@ -8,7 +8,7 @@ mkdir -p build
     find src/ -name \*.nt |sed -e 's,/,.,g' -e 's/^src.\(.*\).nt$/import \1;/'
 ) > build/unittest.nt
 
-LLVM_CONFIG=${LLVM_CONFIG:-"/usr/lib/llvm/14/bin/llvm-config"}
+LLVM_CONFIG=${LLVM_CONFIG:-"/usr/bin/llvm-config-14"}
 FLAGS="${FLAGS} -I$($LLVM_CONFIG --includedir) -L-L$($LLVM_CONFIG --libdir)"
 
 neat -unittest -no-main $PACKAGES $FLAGS build/unittest.nt -o build/unittest


### PR DESCRIPTION
On my Linux Mint 21 system llvm-config is in `/usr/lib/llvm-14/bin`, not `/usr/lib/llvm/14/bin`. `release-gcc.sh` tries both but `build.sh` and `unittest.sh` only try the former. Instead, both Ubuntu and Mint seem to have `/usr/bin/llvm-config-14`, so using that seems potentially more portable.